### PR TITLE
pdd from volodya-lombrozo

### DIFF
--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: g4s8/pdd-action@master
+      - uses: volodya-lombrozo/pdd-action@master


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the PDD GitHub Actions workflow to use the `volodya-lombrozo/pdd-action` instead of `g4s8/pdd-action`.

### Detailed summary
- Updated the `uses` field in the PDD workflow to use `volodya-lombrozo/pdd-action` instead of `g4s8/pdd-action`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->